### PR TITLE
fix parse err

### DIFF
--- a/nonebot/adapters/telegram/model.py
+++ b/nonebot/adapters/telegram/model.py
@@ -251,8 +251,6 @@ class Animation(BaseModel):
 class Audio(BaseModel):
     file_id: str
     file_unique_id: str
-    width: int
-    height: int
     duration: int
     performer: Optional[str] = None
     title: Optional[str] = None


### PR DESCRIPTION
```
Jul 10 21:26:35 UbuntuW2 start.sh[2584926]: pydantic.error_wrappers.ValidationError: 2 validation errors for CallbackQueryEvent
Jul 10 21:26:35 UbuntuW2 start.sh[2584926]: message -> audio -> width
Jul 10 21:26:35 UbuntuW2 start.sh[2584926]:   field required (type=value_error.missing)
Jul 10 21:26:35 UbuntuW2 start.sh[2584926]: message -> audio -> height
Jul 10 21:26:35 UbuntuW2 start.sh[2584926]:   field required (type=value_error.missing)
```